### PR TITLE
Decrease parallel process count for DocumentBuilder rspec tests

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -108,7 +108,7 @@ def linuxBuild(String branch = 'master', String platform = 'native', Boolean cle
     sh "docker rmi doc-builder-testing || true"
     sh "cd doc-builder-testing &&\
         docker build --tag doc-builder-testing -f dockerfiles/debian-develop/Dockerfile . &&\
-        docker run --rm doc-builder-testing"
+        docker run --rm doc-builder-testing parallel_rspec spec -n 2"
 
     return this
 }


### PR DESCRIPTION
Default value of 3 (of process count) resulted that
1 process took around 11 minutes to finish
2 process took around 11 minutes to finish
3 process took around 105 minutes of finish and total task time was over one and half hour
This is very bad

Trying to run in single process mode on my lenovo notebook took around 30 minutes, in 2 process mode - took around 20 minutes, almost same time it took on travis-ci, so I find we should leave 2 process until troubles with granting correct process time on virtual machine is resolved