### PR TITLE
Fix calling parallel_rspec in DocumentBuilder tests

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -108,7 +108,7 @@ def linuxBuild(String branch = 'master', String platform = 'native', Boolean cle
     sh "docker rmi doc-builder-testing || true"
     sh "cd doc-builder-testing &&\
         docker build --tag doc-builder-testing -f dockerfiles/debian-develop/Dockerfile . &&\
-        docker run --rm doc-builder-testing parallel_rspec spec -n 2"
+        docker run --rm doc-builder-testing bundle exec parallel_rspec spec -n 2"
 
     return this
 }


### PR DESCRIPTION
Possible solution for error
```
docker run --rm doc-builder-testing parallel_rspec spec -n 2
docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"parallel_rspec\": executable file not found in $PATH": unknown.
```