### PR TITLE
Allow default build of DocumentBuilder on develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
       name: 'desktopeditor'
     )
     booleanParam (
-      defaultValue: false,
+      defaultValue: true,
       description: 'Build and publish DocumentBuilder packages',
       name: 'documentbuilder'
     )


### PR DESCRIPTION
This product usually have little attention and forgotten to check

And there is some new changes done by @k0r0l that require new version of DocumentBuilder and several bugs in current develop version, that need to be fixed and checked on newer versions